### PR TITLE
Fix logout routes and remember me

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+
+function getLogoutRoute() {
+    if(Str::startsWith(Route::currentRouteName(), 'admin')) {
+        return 'admin.logout';
+    }
+    return 'user.logout';
+}
+
+function notLoginPage() {
+    return !Str::endsWith(Route::currentRouteName(), 'login');
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
         ],
         "psr-4": {
             "App\\": "app/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -52,7 +52,7 @@
                         @if (Auth::guest())
                             <li><a href="{{ route('login') }}">Login</a></li>
                             <li><a href="{{ route('register') }}">Register</a></li>
-                        @else
+                        @elseif (notLoginPage())
                             <li class="dropdown">
                                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
                                     {{ Auth::user()->name }} <span class="caret"></span>
@@ -60,13 +60,13 @@
 
                                 <ul class="dropdown-menu" role="menu">
                                     <li>
-                                        <a href="{{ route('logout') }}"
+                                        <a href="{{ route(getLogoutRoute()) }}"
                                             onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">
                                             Logout
                                         </a>
 
-                                        <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                                        <form id="logout-form" action="{{ route(getLogoutRoute()) }}" method="POST" style="display: none;">
                                             {{ csrf_field() }}
                                         </form>
                                     </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,13 +18,13 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', 'HomeController@index');
-Route::get('/users/logout', 'Auth\LoginController@userLogout')->name('user.logout');
+Route::post('/users/logout', 'Auth\LoginController@userLogout')->name('user.logout');
 
 Route::prefix('admin')->group(function() {
   Route::get('/login', 'Auth\AdminLoginController@showLoginForm')->name('admin.login');
   Route::post('/login', 'Auth\AdminLoginController@login')->name('admin.login.submit');
   Route::get('/', 'AdminController@index')->name('admin.dashboard');
-  Route::get('/logout', 'Auth\AdminLoginController@logout')->name('admin.logout');
+  Route::post('/logout', 'Auth\AdminLoginController@logout')->name('admin.logout');
 
   // Password reset routes
   Route::post('/password/email', 'Auth\AdminForgotPasswordController@sendResetLinkEmail')->name('admin.password.email');


### PR DESCRIPTION
Hi,

Thank you for your Multi Auth tutorials, they are very helpful. I have noticed a bug though - if you tick `Remember Me` when logging in, logging out does not work. This is because the logout functions we created in Part 4 are never being accessed. Currently, clicking logout takes you to Laravel's default `/logout` page instead of `/users/logout` and `/admin/logout`. 

To fix this, I have:

- Created a `helpers.php` file which contains two functions that can run in our blade file. One hides the logout dialogue from the admin login page, and the other returns the correct logout route.
- Changed the logout routes to POST,  as that is what Laravel is expecting.

Thanks :+1: